### PR TITLE
Handle the case where x-ray has been disabled and thre is no sub-segm…

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,19 +27,26 @@ module.exports.addPromiseSegment = function (segmentName, inputPromise, metadata
         try {
             XRay.captureAsyncFunc(segmentName, (subSegment) => {
                 try {
-                    addMetadata(subSegment, metadata);
-                    addAnnotations(subSegment, annotations);
 
-                    inputPromise
-                        .then(val => {
-                            resolve(val);
-                            subSegment.close();
-                        })
-                        .catch(err => {
-                            reject(err);
-                            subSegment.addError(err);
-                            subSegment.close();
-                        });
+                    if (!subSegment) {
+                        return inputPromise
+                            .then(val => resolve(val))
+                            .catch(err => reject(err));
+                    } else {
+                        addMetadata(subSegment, metadata);
+                        addAnnotations(subSegment, annotations);
+
+                        inputPromise
+                            .then(val => {
+                                resolve(val);
+                                subSegment.close();
+                            })
+                            .catch(err => {
+                                reject(err);
+                                subSegment.addError(err);
+                                subSegment.close();
+                            });
+                    }
                 } catch(err) {
                     reject(err);
                 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -159,4 +159,29 @@ describe("addPromiseSegment", function () {
 
         addPromiseSegment(segmentName, Promise.resolve(), {}, annotations);
     });
+
+    it("handles xray being disabled", (done) => {
+        const annotations = {
+            "one": 1,
+            "two": "22",
+            "three": 333
+        };
+        let callCount = 0;
+
+        // when xray is disabled, captureAsyncFunc is called without a sub-segment
+        const subSegment = undefined;
+        
+        captureAsyncFuncValidation = (name, func) => {
+            func(subSegment);
+        };
+    
+        addPromiseSegment(segmentName, Promise.resolve(), {}, annotations)
+            .then(() => {
+                done();
+            }).catch((err) => {
+                done(new Error("Failed: " + err));
+            });
+    });
+    
+    
 });


### PR DESCRIPTION
If x-ray is disabled (for local testing for example), no subSegment is passed in to the callback of captureAsyncFunc(). This fixes the crash that happens in that case.